### PR TITLE
Rename IaC drift command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,10 @@ report:
 	$(BIN)/python -m src.main report $(ARGS)
 
 upgrade-path:
-	$(BIN)/python -m src.main upgrade-path $(ARGS)
+        $(BIN)/python -m src.main upgrade-path $(ARGS)
 
-drift:
-	$(BIN)/python -m src.main drift $(ARGS)
+iac-drift:
+        $(BIN)/python -m src.main iac-drift $(ARGS)
 
 # Historical tracking commands
 history:

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ make upgrade-path ARGS="v1.25.0"
 make upgrade-path ARGS="v1.25.0 v1.30.0"
 ```
 
-### 4. Drift Analysis - Compare IaC with running cluster
+### 4. IaC Drift Analysis - Compare IaC with running cluster
 ```bash
 # Compare IaC with cluster state
-make drift ARGS="/path/to/iac ./k8s-resources"
+make iac-drift ARGS="/path/to/iac ./k8s-resources"
 
 # Hide EKS system resources for cleaner output
-make drift ARGS="/path/to/iac ./k8s-resources --hide-system"
+make iac-drift ARGS="/path/to/iac ./k8s-resources --hide-system"
 ```
 
 ### 5. Historical Commands - Track Changes Over Time
@@ -233,13 +233,13 @@ make upgrade-path ARGS="v1.25.0"
 make upgrade-path ARGS="v1.25.0 v1.34.0"
 ```
 
-#### Drift Analysis
+#### IaC Drift Analysis
 ```bash
 # Compare IaC with cluster reality
-make drift ARGS="~/workspace/syntin/infra/k8s ./k8s-resources"
+make iac-drift ARGS="~/workspace/syntin/infra/k8s ./k8s-resources"
 
 # Focus on app drift, hide system resources
-make drift ARGS="~/workspace/syntin/infra/k8s ./k8s-resources --hide-system"
+make iac-drift ARGS="~/workspace/syntin/infra/k8s ./k8s-resources --hide-system"
 ```
 
 #### Historical Tracking

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -407,8 +407,8 @@ def upgrade_path(
         raise typer.Exit(1)
 
 
-@app.command()
-def drift(
+@app.command("iac-drift")
+def iac_drift(
     iac_path: str = typer.Argument(..., help="Path to IaC directory"),
     cluster_path: str = typer.Argument(
         "./k8s-resources", help="Path to cluster export directory (default: ./k8s-resources)"


### PR DESCRIPTION
## Summary
- Rename IaC vs cluster drift function to `iac_drift` and expose as `iac-drift` command
- Update Makefile and README to reference new `iac-drift` CLI command

## Testing
- `python -m src.main --help`
- `pytest -q` *(fails: kubectl not found and unsupported database dialect errors)*

------
https://chatgpt.com/codex/tasks/task_e_68953bf91ebc8331a32c7fbb2022d487