### PR TITLE
Detect deprecated Kubernetes APIs in cluster reports

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -350,9 +350,8 @@ def report(
 
             console.print(f"[green]✓[/green] Report saved to: [cyan]{report_path}[/cyan]")
 
-            # Also print to console if text format
-            if format == ReportFormat.TEXT:
-                console.print("\n" + report_content)
+            # Always print report content to console
+            console.print("\n" + report_content)
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {str(e)}")

--- a/src/model/report.py
+++ b/src/model/report.py
@@ -45,6 +45,16 @@ class ResourceSummary(BaseModel):
     non_helm_managed: int = 0
 
 
+class ResourceUpgradeAction(BaseModel):
+    """Recommended upgrade action for a specific resource."""
+
+    name: str
+    kind: str
+    namespace: Optional[str] = None
+    current_version: str
+    suggested_version: str
+
+
 class ClusterReport(BaseModel):
     """Complete cluster report."""
 
@@ -54,3 +64,4 @@ class ClusterReport(BaseModel):
     helm_repositories: List[HelmRepository] = Field(default_factory=list)
     resources: ResourceSummary
     upgrade_suggestions: Optional[UpgradeSuggestion] = None
+    resource_upgrade_actions: List[ResourceUpgradeAction] = Field(default_factory=list)

--- a/tests/test_deprecated_api_detection.py
+++ b/tests/test_deprecated_api_detection.py
@@ -1,0 +1,35 @@
+import yaml
+from src.upgrade.advisor import UpgradeAdvisor
+from src.model.kubernetes import K8sResource
+
+sample_manifest = """
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: old-deployment
+  namespace: default
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: old-ingress
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: new-deployment
+  namespace: default
+"""
+
+def test_deprecated_api_detection():
+    resources = []
+    for doc in yaml.safe_load_all(sample_manifest):
+        doc["api_version"] = doc.pop("apiVersion")
+        resources.append(K8sResource(**doc))
+    advisor = UpgradeAdvisor()
+    actions = advisor.get_deprecated_resources(resources)
+    assert len(actions) == 2
+    mapping = {(a.kind, a.name): a.suggested_version for a in actions}
+    assert mapping[("Deployment", "old-deployment")] == "apps/v1"
+    assert mapping[("Ingress", "old-ingress")] == "networking.k8s.io/v1"


### PR DESCRIPTION
## Summary
- flag resources using deprecated APIs and recommend modern versions
- include per-resource upgrade actions in cluster reports and CLI output
- add tests for deprecated API detection

## Testing
- `pytest tests/test_deprecated_api_detection.py`
- `pytest tests/test_upgrade_advisor.py::TestUpgradeAdvisor::test_get_suggestions_valid_version`
- `pytest` *(fails: kubectl command not found, missing DAO attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68953e72fe3c83318c3291aeb5e41ebc